### PR TITLE
feat(#16): implement new no-p2p logic

### DIFF
--- a/src/modules/no-p2p.ts
+++ b/src/modules/no-p2p.ts
@@ -1,54 +1,20 @@
 import { noop } from 'foxts/noop';
-import { createRetrieKeywordFilter } from 'foxts/retrie';
 import { logger } from '../logger';
 import type { MakeBilibiliGreatThanEverBeforeModule } from '../types';
 import { defineReadonlyProperty } from '../utils/define-readonly-property';
-import { pickOne } from 'foxts/pick-random';
+import { getCDNUtil } from '../utils/get-cdn-url';
+import { never } from 'foxts/guard';
+import { createRetrieKeywordFilter } from 'foxts/retrie';
+import { onDOMContentLoaded } from '../utils/on-load-event';
 
-const rBackupCdn = /(?:up|cn-)[\w-]+\.bilivideo\.com/g;
-const isP2PCDNDomainPatterm = createRetrieKeywordFilter([
-  '.mcdn.bilivideo',
-  '.szbdyd.com',
-  '.nexusedgeio.com',
-  '.ahdohpiechei.com' // 七牛云 PCDN
+const knownNonVideoPattern = createRetrieKeywordFilter([
+  'bilibili.com',
+  'hdslb.com',
+  'bvc.bilivideo.com'
 ]);
-function isP2PCDNDomain(domain: string) {
-  return isP2PCDNDomainPatterm(domain)
-    || (domain.includes('bilivideo') && domain.includes('302'));
-}
-const isP2PCDNUrl = createRetrieKeywordFilter([
-  'os=mcdn'
-]);
-
-let prevLocationHref = '';
-let prevCdnDomains: string[] = [];
-function getCDNDomain() {
-  if (prevLocationHref !== unsafeWindow.location.href || prevCdnDomains.length === 0) {
-    try {
-      const matched = Array.from(new Set(Array.from(document.head.innerHTML.matchAll(rBackupCdn), match => match[0]))).filter(domain => !isP2PCDNDomain(domain));
-
-      if (matched.length > 0) {
-        prevLocationHref = unsafeWindow.location.href;
-        prevCdnDomains = matched;
-
-        logger.info('Get CDN domains from <head />', { matched });
-      } else {
-        logger.warn('Failed to get CDN domains from document.head.innerHTML, fallback to default CDN domain');
-        prevLocationHref = unsafeWindow.location.href;
-        prevCdnDomains = ['upos-sz-mirrorcoso1.bilivideo.com'];
-        return 'upos-sz-mirrorcoso1.bilivideo.com';
-      }
-    } catch (e) {
-      logger.error('Failed to get CDN domains from document.head.innerHTML, fallback to default CDN domain', e);
-      prevLocationHref = unsafeWindow.location.href;
-      prevCdnDomains = ['upos-sz-mirrorcoso1.bilivideo.com'];
-      return 'upos-sz-mirrorcoso1.bilivideo.com';
-    }
-  }
-
-  return prevCdnDomains.length === 1
-    ? prevCdnDomains[0]
-    : pickOne(prevCdnDomains);
+function isKnownNonVideoUrl(url: string | URL): boolean {
+  const urlStr = url.toString();
+  return knownNonVideoPattern(urlStr);
 }
 
 const noP2P: MakeBilibiliGreatThanEverBeforeModule = {
@@ -67,6 +33,29 @@ const noP2P: MakeBilibiliGreatThanEverBeforeModule = {
     defineReadonlyProperty(unsafeWindow, 'BPP2PSDK', MockBPP2PSDK);
     defineReadonlyProperty(unsafeWindow, 'SeederSDK', MockSeederSDK);
 
+    if ('__playinfo__' in unsafeWindow && typeof unsafeWindow.__playinfo__ === 'object' && unsafeWindow.__playinfo__) {
+      getCDNUtil().saveAndParsePlayerInfo(unsafeWindow.__playinfo__, 'unsafeWindow.__playinfo__', false);
+    } else {
+      logger.debug('No unsafeWindow.__playinfo__ found on script load, wait for DOMContentLoaded and check again.');
+      onDOMContentLoaded(() => {
+        if ('__playinfo__' in unsafeWindow && typeof unsafeWindow.__playinfo__ === 'object' && unsafeWindow.__playinfo__) {
+          getCDNUtil().saveAndParsePlayerInfo(unsafeWindow.__playinfo__, 'unsafeWindow.__playinfo__ (DOMContentLoaded)', false);
+        }
+      });
+    }
+
+    onXhrResponse((_method, url, response, _xhr) => {
+      if (url.toString().includes('api.bilibili.com/x/player/wbi/playurl') && typeof response === 'string') {
+        try {
+          getCDNUtil().saveAndParsePlayerInfo(JSON.parse(response), 'playurl XHR API', true);
+        } catch (e) {
+          logger.error('Failed to parse playinfo XHR API JSON', e, { response });
+        };
+      }
+
+      return response;
+    });
+
     // Patch new Native Player
     (function (HTMLMediaElementPrototypeSrcDescriptor) {
       Object.defineProperty(unsafeWindow.HTMLMediaElement.prototype, 'src', {
@@ -75,11 +64,16 @@ const noP2P: MakeBilibiliGreatThanEverBeforeModule = {
           if (typeof value !== 'string') {
             value = String(value);
           }
-          try {
-            const result = replaceP2P(value, getCDNDomain, 'HTMLMediaElement.prototype.src');
-            value = typeof result === 'string' ? result : result.href;
-          } catch (e) {
-            logger.error('Failed to handle HTMLMediaElement.prototype.src setter', e, { value });
+
+          if (!value.startsWith('blob:')) {
+            // we don't care about blob urls
+            // they will use another way to fetch the real url and turn it into blob url anyway
+            // we can intercept that fetch/XHR instead
+            try {
+              value = getCDNUtil().getReplacementCdnUrl(value, 'HTMLMediaElement.prototype.src');
+            } catch (e) {
+              logger.error('Failed to handle HTMLMediaElement.prototype.src setter', e, { value });
+            }
           }
 
           HTMLMediaElementPrototypeSrcDescriptor?.set?.call(this, value);
@@ -88,89 +82,35 @@ const noP2P: MakeBilibiliGreatThanEverBeforeModule = {
     }(Object.getOwnPropertyDescriptor(unsafeWindow.HTMLMediaElement.prototype, 'src')));
 
     onXhrOpen((xhrOpenArgs) => {
+      const xhrUrl = xhrOpenArgs[1];
+      if (isKnownNonVideoUrl(xhrUrl)) {
+        return xhrOpenArgs;
+      }
+
       try {
-        xhrOpenArgs[1] = replaceP2P(
-          xhrOpenArgs[1],
-          getCDNDomain,
-          'XMLHttpRequest.prototype.open'
-        );
+        xhrOpenArgs[1] = getCDNUtil().getReplacementCdnUrl(xhrUrl, 'XMLHttpRequest.prototype.open');
       } catch (e) {
-        logger.error('Failed to replace P2P for XMLHttpRequest.prototype.open', e, { xhrUrl: xhrOpenArgs[1] });
+        logger.error('Failed to replace P2P for XMLHttpRequest.prototype.open', e, { xhrUrl });
       }
 
       return xhrOpenArgs;
     });
 
-    onXhrResponse((_method, url, response, _xhr) => {
-      if (typeof response === 'string' && url.toString().includes('api.bilibili.com/x/player/wbi/playurl')) {
-        try {
-          const json: object = JSON.parse(response);
-
-          const cdnDomains = new Set<string>();
-
-          function addCDNFromUrl(url: unknown) {
-            if (typeof url === 'string' && !isP2PCDNDomain(url) && !isP2PCDNUrl(url)) {
-              try {
-                cdnDomains.add(new URL(url).hostname);
-              } catch {}
-            }
-          }
-          function extractCDNFromVideoOrAudio(data: unknown) {
-            if (Array.isArray(data)) {
-              for (const videoOrAudio of data) {
-                if ('baseUrl' in videoOrAudio && typeof videoOrAudio.baseUrl === 'string') {
-                  addCDNFromUrl(videoOrAudio.baseUrl);
-                }
-                if ('base_url' in videoOrAudio && typeof videoOrAudio.base_url === 'string') {
-                  addCDNFromUrl(videoOrAudio.base_url);
-                }
-
-                if ('backupUrl' in videoOrAudio && Array.isArray(videoOrAudio.backupUrl)) {
-                  videoOrAudio.backupUrl.forEach(addCDNFromUrl);
-                }
-                if ('backup_url' in videoOrAudio && Array.isArray(videoOrAudio.backup_url)) {
-                  videoOrAudio.backup_url.forEach(addCDNFromUrl);
-                }
-              }
-            }
-          }
-
-          if (
-            'data' in json && typeof json.data === 'object' && json.data
-            && 'dash' in json.data && typeof json.data.dash === 'object' && json.data.dash
-          ) {
-            if ('video' in json.data.dash) {
-              extractCDNFromVideoOrAudio(json.data.dash.video);
-            }
-            if ('audio' in json.data.dash) {
-              extractCDNFromVideoOrAudio(json.data.dash.audio);
-            }
-          }
-
-          logger.info('Get CDN domains from Bilibili API', { json, cdnDomains });
-
-          if (cdnDomains.size > 0) {
-            prevLocationHref = unsafeWindow.location.href;
-            prevCdnDomains = Array.from(cdnDomains);
-          }
-        } catch { };
-      }
-
-      return response;
-    });
-
     onBeforeFetch((fetchArgs: [RequestInfo | URL, RequestInit?]) => {
       let input = fetchArgs[0];
-      if (typeof input === 'string' || 'href' in input) {
-        input = replaceP2P(input, getCDNDomain, 'fetch');
-      } else if ('url' in input) {
-        input = new Request(replaceP2P(input.url, getCDNDomain, 'fetch'), input);
+      if (typeof input === 'string' || 'href' in input) { // string | URL
+        if (!isKnownNonVideoUrl(input)) {
+          input = getCDNUtil().getReplacementCdnUrl(input, 'fetch');
+          fetchArgs[0] = input;
+        }
+      } else if ('url' in input) { // Request
+        if (!isKnownNonVideoUrl(input.url)) {
+          input = new Request(getCDNUtil().getReplacementCdnUrl(input.url, 'fetch'), input);
+          fetchArgs[0] = input;
+        }
       } else {
-        const _: never = input;
-        // input = replaceP2P(String(input), cdnDomain);
+        never(input, 'fetchArgs[0]');
       }
-
-      fetchArgs[0] = input;
 
       return fetchArgs;
     });
@@ -178,42 +118,3 @@ const noP2P: MakeBilibiliGreatThanEverBeforeModule = {
 };
 
 export default noP2P;
-
-function replaceP2P(url: string | URL, cdnDomainGetter: () => string, meta = ''): string | URL {
-  try {
-    if (typeof url === 'string') {
-      // early bailout for better performance
-      if (!isP2PCDNDomain(url) && !isP2PCDNUrl(url)) {
-        return url;
-      }
-
-      if (url.startsWith('//')) {
-        url = unsafeWindow.location.protocol + url;
-      }
-      url = new URL(url, unsafeWindow.location.href);
-    } else if (!isP2PCDNDomain(url.hostname) && !isP2PCDNUrl(url.href)) {
-      // early bailout for better performance
-      return url;
-    }
-    const hostname = url.hostname;
-    if (hostname.endsWith('.szbdyd.com')) {
-      const xy_usource = url.searchParams.get('xy_usource');
-      if (xy_usource) {
-        url.hostname = xy_usource;
-        url.port = '443';
-        logger.info(`P2P replaced: ${hostname} -> ${xy_usource}`, { meta });
-      }
-    } else {
-      const cdn = cdnDomainGetter();
-      url.protocol = 'https:';
-      url.hostname = cdn;
-      url.port = '443';
-      logger.info(`P2P replaced: ${hostname} -> ${cdn}`, { meta });
-    }
-
-    return url;
-  } catch (e) {
-    logger.error(`Failed to replace P2P for URL (${url}):`, e);
-    return url;
-  }
-}

--- a/src/modules/no-p2p.ts
+++ b/src/modules/no-p2p.ts
@@ -50,7 +50,7 @@ const noP2P: MakeBilibiliGreatThanEverBeforeModule = {
           getCDNUtil().saveAndParsePlayerInfo(JSON.parse(response), 'playurl XHR API', true);
         } catch (e) {
           logger.error('Failed to parse playinfo XHR API JSON', e, { response });
-        };
+        }
       }
 
       return response;

--- a/src/utils/get-cdn-url.ts
+++ b/src/utils/get-cdn-url.ts
@@ -1,0 +1,440 @@
+import { pickOne } from 'foxts/pick-random';
+import { createRetrieKeywordFilter } from 'foxts/retrie';
+import { logger } from '../logger';
+
+const PROXY_TF = 'proxy-tf-all-ws.bilivideo.com';
+const FALLBACK_CDN_HOST = 'upos-sz-mirrorali.bilivideo.com';
+
+const MCDN_UPGCXCODE_URL_HOSTNAME_TO_BE_REPLACED = 'make-bilibili-great-than-ever-before.secret-internal-do-not-use-or-you-will-be-fired.nxdomain.skk.moe';
+
+const mirrorRegex = /^https?:\/\/(?:upos-\w+-(?!302)\w+|(?:upos|proxy)-tf-[^/]+)\.(?:bilivideo|akamaized)\.(?:com|net)\/upgcxcode/;
+const mCdnTfRegex = /^https?:\/\/(?:(?:\d{1,3}\.){3}\d{1,3}|[^/]+\.mcdn\.bilivideo\.(?:com|cn|net))(?::\d{1,5})?\/v\d\/resource/;
+
+const knownP2pCdnDomainPattern = createRetrieKeywordFilter([
+  '302ppio',
+  '302kodo',
+  '.mcdn.bilivideo',
+  '.szbdyd.com',
+  '.nexusedgeio.com',
+  '.ahdohpiechei.com' // 七牛云 PCDN
+]);
+
+function isP2PCDNDomain(hostname: string): boolean {
+  if (knownP2pCdnDomainPattern(hostname)) {
+    return true;
+  }
+  // upos-sz-302ppio.bilivideo.com -> *.nexusedgeio.com
+  // upos-sz-302kodo.bilivideo.com -> *.ahdohpiechei.com
+  // pattern: *-*302*.*
+  const subdomain = hostname.split('.', 1)[0];
+  return subdomain.includes('302');
+}
+
+function createCDNUtil() {
+  interface CdnUrlData {
+    knownUrls: Set<string>,
+    replacementType: string,
+    getReplacementUrl(incomingUrl: string | URL): string,
+    // Optional meta
+    mirror_urls?: Set<string>,
+    bacache_urls?: Set<string>,
+    mcdn_upgcxcode_urls?: Set<string>,
+    xyusourceUrls?: Set<string>,
+    mcdn_tf_urls?: Set<string>
+  }
+
+  // All upgcxcode hosts are interchangeable, so we collect them here
+  const mirror_type_upgcxcode_hosts = new Set<string>();
+  const bcache_type_upgcxcode_hosts = new Set<string>();
+
+  const cdnDatas: CdnUrlData[] = [];
+
+  return {
+    saveAndParsePlayerInfo(json: object, meta: string, shouldOverwrite = false) {
+      if (cdnDatas.length > 0) {
+        if (!shouldOverwrite) {
+          logger.debug('CDN URLs already extracted, skip parsing again.', { meta });
+          return;
+        }
+
+        logger.debug('Overwritten existing CDN URLs, re-parse playinfo.', { meta });
+        cdnDatas.length = 0;
+      }
+
+      if (
+        (!('data' in json)) || typeof json.data !== 'object' || json.data === null
+        || (!('dash' in json.data)) || typeof json.data.dash !== 'object' || json.data.dash === null
+      ) {
+        logger.warn('Invalid Bilibili Playinfo data', { json });
+        return;
+      }
+
+      if ('video' in json.data.dash && Array.isArray(json.data.dash.video)) {
+        extractCDNFromVideoOrAudio(json.data.dash.video);
+      }
+      if ('audio' in json.data.dash && Array.isArray(json.data.dash.audio)) {
+        extractCDNFromVideoOrAudio(json.data.dash.audio);
+      }
+
+      logger.info('CDN URLs extracted', { meta, cdnDatas });
+    },
+    getReplacementCdnUrl(url: string | URL, meta: string): string {
+      if (cdnDatas.length === 0) {
+        const urlObj = typeof url === 'string' ? new URL(url) : url;
+        if (!isP2PCDNDomain(urlObj.hostname)) {
+          return urlObj.href;
+        }
+
+        return basicP2PReplacement(urlObj, meta);
+      }
+
+      for (let i = 0, len = cdnDatas.length; i < len; i++) {
+        const cdnData = cdnDatas[i];
+        if (!cdnData.knownUrls.has(url.toString())) {
+          continue;
+        }
+
+        return cdnData.getReplacementUrl(url);
+      }
+
+      logger.error('No matching CDN URL Group found!', { meta, url });
+      return url.toString();
+    }
+  };
+
+  function extractCDNFromVideoOrAudio(data: unknown[]) {
+    // In the data there is an array of baseUrl/backupUrl objects
+    // Each array consists of different quality levels
+    // We do not care about the quality levels, just extract all URLs per group
+    // Which we will be matching against later
+    for (const videoOrAudio of data) {
+      if (typeof videoOrAudio !== 'object' || videoOrAudio === null) {
+        continue;
+      }
+
+      const knownUrls = new Set<string>();
+
+      if ('baseUrl' in videoOrAudio && typeof videoOrAudio.baseUrl === 'string') {
+        knownUrls.add(videoOrAudio.baseUrl);
+      }
+      if ('base_url' in videoOrAudio && typeof videoOrAudio.base_url === 'string') {
+        knownUrls.add(videoOrAudio.base_url);
+      }
+      if ('backupUrl' in videoOrAudio && Array.isArray(videoOrAudio.backupUrl)) {
+        videoOrAudio.backupUrl.forEach((url: string) => knownUrls.add(url));
+      }
+      if ('backup_url' in videoOrAudio && Array.isArray(videoOrAudio.backup_url)) {
+        videoOrAudio.backup_url.forEach((url: string) => knownUrls.add(url));
+      }
+
+      // After collecting all known URLs, we can now process them
+      let last = '';
+      const mirror_urls = new Set<string>();
+      const bcache_urls = new Set<string>();
+
+      const mcdn_tf_urls = new Set<string>();
+      const mcdn_upgcxcode_urls = new Set<string>();
+      const xyusourceUrls = new Set<string>();
+
+      for (const urlStr of knownUrls) {
+        last = urlStr;
+
+        try {
+          if (mirrorRegex.test(urlStr)) {
+            if (urlStr.includes('/upgcxcode/')) {
+              const url = new URL(urlStr);
+
+              // Now we konw this url is both upgcxcode type url and mirror type url
+              // Since all upgcxcode urls are interchangeable, we can collect its host
+              if (
+                // It is possible for a mirror type url to also be a p2p cdn:
+                //
+                // upos-sz-mirrorcoso1.bilivideo.com os=mcdn
+                // upos-\w*-302.* (HTTP 302 p2p cdn)
+                url.searchParams.get('os') !== 'mcdn'
+                && !isP2PCDNDomain(url.hostname)
+              ) {
+                mirror_type_upgcxcode_hosts.add(url.hostname);
+
+                // Now we know this url is mirror type url and not p2p cdn
+                // let's ensure it is HTTPS and add to mirror urls
+                url.protocol = 'https:';
+                url.port = '443';
+
+                mirror_urls.add(url.href);
+              } else {
+                // Now we know this url is mirror type url, upgcxcode url, and p2p cdn url
+                url.protocol = 'https:';
+                url.port = '443';
+
+                // since we will replace its hostname anyway, the original hostname
+                // does not matter, we use a fixed dummy hostname here, and better
+                // reduce duplicates in the Set<string>.
+                url.hostname = MCDN_UPGCXCODE_URL_HOSTNAME_TO_BE_REPLACED;
+
+                mcdn_upgcxcode_urls.add(urlStr);
+              }
+            }
+
+            continue;
+          }
+
+          if (mCdnTfRegex.test(urlStr)) {
+            // This is mcdn type url, a.k.a. pure IP cdn url or mcdn.bilivideo.*
+            mcdn_tf_urls.add(urlStr);
+            continue;
+          }
+
+          if (urlStr.includes('/upgcxcode/')) {
+            const url = new URL(urlStr);
+
+            // Now we know this is upgcxcode type url, but not mirror type url:
+            if (isP2PCDNDomain(url.hostname)) {
+              // *.mcdn.bilivideo.* (mcdn type url p2p cdn)
+              // upos-\w*-302.* (HTTP 302 p2p cdn)
+
+              url.protocol = 'https:';
+              url.port = '443';
+
+              // since we will replace its hostname anyway, the original hostname
+              // does not matter, we use a fixed dummy hostname here, and better
+              // reduce duplicates in the Set<string>.
+              url.hostname = MCDN_UPGCXCODE_URL_HOSTNAME_TO_BE_REPLACED;
+
+              mcdn_upgcxcode_urls.add(urlStr);
+            } else {
+              // bcache type url (self hosted PoP):
+              // cn-sccd-cu-01-01.bilivideo.com
+              // (more details in https://rec.danmuji.org/dev/cdn-info/ )
+
+              // we can collect its host for later replacement
+              bcache_type_upgcxcode_hosts.add(url.hostname);
+
+              bcache_urls.add(urlStr);
+            }
+            continue;
+          }
+
+          // szbdyd.com appears to be deprecated, but we still handle it just in case
+          if (urlStr.includes('szbdyd.com')) {
+            const url = new URL(urlStr);
+
+            url.protocol = 'https:';
+
+            // szbdyd hostname can be replaced with the value of xy_usource query param
+            // and if xy_usource is missing, we can replace to upgcxcode host
+            url.hostname = url.searchParams.get('xy_usource') ?? MCDN_UPGCXCODE_URL_HOSTNAME_TO_BE_REPLACED;
+            url.port = '443';
+
+            xyusourceUrls.add(url.href);
+            continue;
+          }
+
+          logger.error(`Unrecognized CDN URL pattern: ${urlStr}`);
+        } catch {
+          // fallthru
+        }
+      }
+
+      let replacementType: string;
+      let getReplacementUrl: (url: string | URL) => string;
+
+      switch (true) {
+        // We always prefer mirror type urls when possible, so as long as we have some,
+        // we always pick one from them
+        case (mirror_urls.size > 0): {
+          replacementType = 'mirror';
+
+          const mirrorUrlsArray = Array.from(mirror_urls);
+          if (mirrorUrlsArray.length === 1) {
+            getReplacementUrl = () => mirrorUrlsArray[0];
+            break;
+          }
+          getReplacementUrl = () => pickOne(mirrorUrlsArray);
+          break;
+        }
+        // bacache urls are not as good as mirror urls, but still better than p2p cdn,
+        // we pick one from them when no mirror urls are available
+        case (bcache_urls.size > 0): {
+          replacementType = 'bcache';
+
+          const bcacheUrlsArray = Array.from(bcache_urls);
+          if (bcacheUrlsArray.length === 1) {
+            getReplacementUrl = () => bcacheUrlsArray[0];
+            break;
+          }
+          getReplacementUrl = () => pickOne(bcacheUrlsArray);
+          break;
+        }
+        // Next we try HTTP 302/MCDN upgcxcode urls, since we can replace their
+        // hosts w/ bcache/mirror type upgcxcode hosts, it is not that bad
+        case (mcdn_upgcxcode_urls.size > 0): {
+          replacementType = 'mcdn upgcxcode -> host replacement';
+
+          const mcdnUpgcxcodeUrlsArray = Array.from(mcdn_upgcxcode_urls);
+
+          if (mcdnUpgcxcodeUrlsArray.length === 1) {
+            getReplacementUrl = () => replaceUpgcxcodeHost(mcdnUpgcxcodeUrlsArray[0]);
+            break;
+          }
+          getReplacementUrl = () => replaceUpgcxcodeHost(pickOne(mcdnUpgcxcodeUrlsArray));
+          break;
+        }
+        // Next we try szbdyd.com urls with either xy_usource or upgcxcode host replacement
+        case (xyusourceUrls.size > 0): {
+          replacementType = 'szbdyd.com -> xy_usource or upgcxcode host replacement';
+
+          const xyusourceUrlsArray = Array.from(xyusourceUrls);
+
+          getReplacementUrl = () => {
+            const picked = pickOne(xyusourceUrlsArray);
+            const url = new URL(picked);
+
+            // If the URL do not have xy_usource, we need to replace with upgcxcode host
+            if (url.hostname === MCDN_UPGCXCODE_URL_HOSTNAME_TO_BE_REPLACED) {
+              // need to replace with upgcxcode host
+              return replaceUpgcxcodeHost(url);
+            }
+            return url.href;
+          };
+          break;
+        }
+        // We are left with pure IP cdn urls, or mcdn.bilivideo.* urls that are not
+        // upgcxcode type, we can return proxy-wrapped mcdn tf url
+        case (mcdn_tf_urls.size > 0): {
+          replacementType = 'mcdn tf -> proxy-wrapped';
+
+          const mcdnTfUrlsArray = Array.from(mcdn_tf_urls);
+
+          getReplacementUrl = () => {
+            const proxyUrl = new URL(`https://${PROXY_TF}`);
+            proxyUrl.searchParams.set('url', pickOne(mcdnTfUrlsArray));
+            return proxyUrl.href;
+          };
+          break;
+        }
+        default: {
+          replacementType = 'none';
+
+          logger.warn('Failed to get replacement CDN URL', { last });
+          getReplacementUrl = (url: string | URL) => url.toString();
+          break;
+        }
+      }
+
+      cdnDatas.push({
+        knownUrls,
+        replacementType,
+        getReplacementUrl,
+        // Optional meta
+        mirror_urls,
+        bacache_urls: bcache_urls,
+        mcdn_upgcxcode_urls,
+        xyusourceUrls,
+        mcdn_tf_urls
+      });
+    }
+  }
+
+  function replaceUpgcxcodeHost(url: string | URL): string {
+    const urlObj = typeof url === 'string' ? new URL(url) : url;
+    urlObj.protocol = 'https:';
+    urlObj.port = '443';
+
+    if (mirror_type_upgcxcode_hosts.size > 0) {
+      const mirror_type_upgcxcode_hosts_array = Array.from(mirror_type_upgcxcode_hosts);
+
+      urlObj.hostname = pickOne(mirror_type_upgcxcode_hosts_array);
+      return urlObj.href;
+    }
+    if (bcache_type_upgcxcode_hosts.size > 0) {
+      const bcache_type_upgcxcode_hosts_array = Array.from(bcache_type_upgcxcode_hosts);
+      urlObj.hostname = pickOne(bcache_type_upgcxcode_hosts_array);
+      return urlObj.href;
+    }
+    urlObj.hostname = FALLBACK_CDN_HOST;
+    return urlObj.href;
+  }
+
+  function basicP2PReplacement(url: URL, meta: string): string {
+    logger.warn('PlayInfo not collected yet! Opt-in basic P2P replacement', { meta, url: url.href });
+
+    const urlStr = url.href;
+
+    // Even if we have not collected any CDN info yet, we can still try our best to avoid P2P CDNs
+    if (mirrorRegex.test(urlStr) && urlStr.includes('/upgcxcode/')) {
+      // Now we konw this url is both upgcxcode type url and mirror type url
+      // Since all upgcxcode urls are interchangeable, we can collect its host
+      if (
+        // It is possible for a mirror type url to also be a p2p cdn:
+        //
+        // upos-sz-mirrorcoso1.bilivideo.com os=mcdn
+        // upos-\w*-302.* (HTTP 302 p2p cdn)
+        url.searchParams.get('os') !== 'mcdn'
+        && !isP2PCDNDomain(url.hostname)
+      ) {
+        mirror_type_upgcxcode_hosts.add(url.hostname);
+
+        // Now we know this url is mirror type url and not p2p cdn
+        // let's ensure it is HTTPS and add to mirror urls
+        url.protocol = 'https:';
+        url.port = '443';
+
+        return url.href;
+      }
+
+      // Now we know this url is os=mcdn/http 302 url, let's replace its host
+      return replaceUpgcxcodeHost(url);
+    }
+
+    if (urlStr.includes('/upgcxcode/')) {
+      // Now we know this is upgcxcode type url, but not mirror type url:
+      if (isP2PCDNDomain(url.hostname)) {
+        // *.mcdn.bilivideo.* (mcdn type url p2p cdn)
+        // upos-\w*-302.* (HTTP 302 p2p cdn)
+        return replaceUpgcxcodeHost(url);
+      }
+      // bcache type url (self hosted PoP):
+      // cn-sccd-cu-01-01.bilivideo.com
+      // (more details in https://rec.danmuji.org/dev/cdn-info/ )
+
+      // we can collect its host for later replacement
+      bcache_type_upgcxcode_hosts.add(url.hostname);
+
+      return urlStr;
+    }
+
+    // szbdyd.com appears to be deprecated, but we still handle it just in case
+    if (urlStr.includes('szbdyd.com')) {
+      const xy_usource = url.searchParams.get('xy_usource');
+      if (xy_usource) {
+        url.protocol = 'https:';
+        url.port = '443';
+        url.hostname = xy_usource;
+
+        return url.href;
+      }
+
+      return replaceUpgcxcodeHost(url);
+    }
+
+    if (mCdnTfRegex.test(urlStr)) {
+      const proxyUrl = new URL(`https://${PROXY_TF}`);
+      proxyUrl.searchParams.set('url', urlStr);
+      return proxyUrl.href;
+    }
+
+    logger.error('Basic P2P replacement failed!', { meta, url: urlStr });
+
+    return urlStr;
+  }
+}
+
+type CDNUtilInstance = ReturnType<typeof createCDNUtil>;
+
+let lastInstance: CDNUtilInstance | null = null;
+
+export function getCDNUtil(): CDNUtilInstance {
+  lastInstance ??= createCDNUtil();
+  return lastInstance;
+}

--- a/src/utils/get-cdn-url.ts
+++ b/src/utils/get-cdn-url.ts
@@ -37,7 +37,7 @@ function createCDNUtil() {
     getReplacementUrl(incomingUrl: string | URL): string,
     // Optional meta
     mirror_urls?: Set<string>,
-    bacache_urls?: Set<string>,
+    bcache_urls?: Set<string>,
     mcdn_upgcxcode_urls?: Set<string>,
     xyusourceUrls?: Set<string>,
     mcdn_tf_urls?: Set<string>
@@ -133,7 +133,7 @@ function createCDNUtil() {
             if (mirrorRegex.test(urlStr)) {
               const url = new URL(urlStr);
 
-              // Now we konw this url is both upgcxcode type url and mirror type url
+              // Now we know this url is both upgcxcode type url and mirror type url
               // Since all upgcxcode urls are interchangeable, we can collect its host
               if (
               // It is possible for a mirror type url to also be a p2p cdn:
@@ -276,7 +276,7 @@ function createCDNUtil() {
             const picked = pickOne(xyusourceUrlsArray);
             const url = new URL(picked);
 
-            // If the URL do not have xy_usource, we need to replace with upgcxcode host
+            // If the URL does not have xy_usource, we need to replace with upgcxcode host
             if (url.hostname === MCDN_UPGCXCODE_URL_HOSTNAME_TO_BE_REPLACED) {
               // need to replace with upgcxcode host
               return replaceUpgcxcodeHost(url);
@@ -314,7 +314,7 @@ function createCDNUtil() {
           getReplacementUrl,
           // Optional meta
           mirror_urls,
-          bacache_urls: bcache_urls,
+          bcache_urls,
           mcdn_upgcxcode_urls,
           xyusourceUrls,
           mcdn_tf_urls
@@ -351,7 +351,7 @@ function createCDNUtil() {
     if (urlStr.includes('/upgcxcode/')) {
       // Even if we have not collected any CDN info yet, we can still try our best to avoid P2P CDNs
       if (mirrorRegex.test(urlStr)) {
-        // Now we konw this url is both upgcxcode type url and mirror type url
+        // Now we know this url is both upgcxcode type url and mirror type url
         // Since all upgcxcode urls are interchangeable, we can collect its host
         if (
           // It is possible for a mirror type url to also be a p2p cdn:

--- a/src/utils/get-cdn-url.ts
+++ b/src/utils/get-cdn-url.ts
@@ -1,3 +1,15 @@
+/**
+ * IMPORTANT NOTICE for those who want to implement similar functionality:
+ *
+ * "Make Bilibili Great Than Ever Before" does not have control of the Bilibili web player, we can
+ * only hijack the HTTP request fired by the Bilibili web player and replace the URL on the fly,
+ * thus we must implement such complex logic.
+ *
+ * If you are implementing a third-party Bilibili player or Bilibili video downloader, you already
+ * have all the control. You can just choose one best URL from the full CDN information and then
+ * move on.
+ */
+
 import { pickOne } from 'foxts/pick-random';
 import { createRetrieKeywordFilter } from 'foxts/retrie';
 import { logger } from '../logger';
@@ -39,7 +51,7 @@ function createCDNUtil() {
     mirror_urls?: Set<string>,
     bcache_urls?: Set<string>,
     mcdn_upgcxcode_urls?: Set<string>,
-    xyusourceUrls?: Set<string>,
+    szbdyd_urls?: Set<string>,
     mcdn_tf_urls?: Set<string>
   }
 
@@ -125,7 +137,7 @@ function createCDNUtil() {
 
       const mcdn_tf_urls = new Set<string>();
       const mcdn_upgcxcode_urls = new Set<string>();
-      const xyusourceUrls = new Set<string>();
+      const szbdyd_urls = new Set<string>();
 
       for (const urlStr of knownUrls) {
         try {
@@ -212,7 +224,7 @@ function createCDNUtil() {
             url.hostname = url.searchParams.get('xy_usource') ?? MCDN_UPGCXCODE_URL_HOSTNAME_TO_BE_REPLACED;
             url.port = '443';
 
-            xyusourceUrls.add(url.href);
+            szbdyd_urls.add(url.href);
             continue;
           }
 
@@ -239,7 +251,7 @@ function createCDNUtil() {
           getReplacementUrl = () => pickOne(mirrorUrlsArray);
           break;
         }
-        // bacache urls are not as good as mirror urls, but still better than p2p cdn,
+        // bcache urls are not as good as mirror urls, but still better than p2p cdn,
         // we pick one from them when no mirror urls are available
         case (bcache_urls.size > 0): {
           replacementType = 'bcache';
@@ -267,10 +279,10 @@ function createCDNUtil() {
           break;
         }
         // Next we try szbdyd.com urls with either xy_usource or upgcxcode host replacement
-        case (xyusourceUrls.size > 0): {
+        case (szbdyd_urls.size > 0): {
           replacementType = 'szbdyd.com -> xy_usource or upgcxcode host replacement';
 
-          const xyusourceUrlsArray = Array.from(xyusourceUrls);
+          const xyusourceUrlsArray = Array.from(szbdyd_urls);
 
           getReplacementUrl = () => {
             const picked = pickOne(xyusourceUrlsArray);
@@ -316,7 +328,7 @@ function createCDNUtil() {
           mirror_urls,
           bcache_urls,
           mcdn_upgcxcode_urls,
-          xyusourceUrls,
+          szbdyd_urls,
           mcdn_tf_urls
         });
       });

--- a/src/utils/get-cdn-url.ts
+++ b/src/utils/get-cdn-url.ts
@@ -218,7 +218,7 @@ function createCDNUtil() {
 
           logger.error(`Unrecognized CDN URL pattern: ${urlStr}`);
         } catch {
-          // fallthru
+          logger.debug('Failed to process CDN URL, skipping.', { url: urlStr });
         }
       }
 


### PR DESCRIPTION
Closes #16.

------

Since "Make Bilibili Great Than Ever Before" does not have control of the Bilibili web player, we can only hijack the HTTP request fired by the Bilibili web player and replace the URL on the fly, thus we must implement such complex logic.

If you are implementing a third-party Bilibili player or video downloader, you already have all the control. You can just choose the best URL from the full CDN information and simply move on.

------

English description: The code speaks for itself.

简体中文：

Make Bilibili Great Than Ever Before（以下简称 MBGTEB）实现了全新的 Bilibili CDN 替换逻辑。

**获取下发的 CDN 信息**

现在 MBGTEB 会永远尝试获取 Bilibili 网页版下发的 CDN 信息。

- 当页面加载时，从 `unsafeWindow.__playinfo__` 获取 CDN 信息
  - 由于各个脚本管理器实现 `unsafeWindow` 的方式不同，有可能 `unsafeWindow` 还没有初始化完成；此时 MBGTEB 会在 `DOMContentLoaded` 事件发生时重新读一次 `unsafeWindow.__playinfo__`
- MBGTEB 还会劫持 XMLHttpRequest，寻找所有 `https://api.bilibili.com/x/player/wbi/playurl` 的 API 请求并从 API 响应中获取 CDN 信息
  - 由于 Bilibili 网页版 是一个 PJAX/SPA 应用，当导航发生时、新视频的 CDN 信息永远是通过 `https://api.bilibili.com/x/player/wbi/playurl` API 获取的。因此，MBGTEB 永远将通过劫持 XHR 获取到的 CDN 信息 视为最高优先级、并替换 之前已经收集过的 CDN 信息

**增强 CDN 替换逻辑**

当 MBGTEB 获取了完成的 CDN 信息（即所有画质下、所有视频和音频的所有 默认与备选 CDN 地址）时，此时 MBGTEB 会启用「增强 CDN 替换逻辑」、确保最优的播放性能：

- 优先使用性能最好的 CDN 类型：`mirror -> bcache -> upgcxcode w/ replaced host -> szbdyd.com w/ replaced host -> proxy tf`
- 每一种 CDN 类型下 可能包含有多个 CDN 地址，此时 MBGTEB 能够在多个 CDN 地址之间负载均衡

完整的 CDN 信息包含以画质为分组的、所有视频和音频的所有 默认与备选 CDN 地址。MBGTEB 并不在乎当前 Bilibili 网页版播放器 选择的画质，而是遍历每个 画质分组 下所有默认与备选 CDN 地址、为每个 画质分组 提前计算 最优 CDN 替换逻辑，并存在一个 Map 中；当后续 MBGTEB 劫持到播放器的视频请求时，通过 Map `O(1)` 查询到当前播放器请求地址所对应的、提前计算好的最优替换逻辑 并执行。

**基础 CDN 替换逻辑**

在 MBGTEB 获取完整 CDN 信息并提前计算「增强 CDN 替换逻辑」之前，Bilibili 网页 可能已经开始发送视频请求：

- MBGTEB 首次读取 `unsafeWindow.__playinfo__` 失败、在等待 `DOMContentLoaded` 事件后重新读取 `unsafeWindow.__playinfo__`，但是此时 Bilibili 网页 可能已经开始预载视频

由于此时 MBGTEB 没有获取到 CDN 信息、没有获取到所有可用 CDN 地址，因此无法使用「增强 CDN 替换逻辑」，此时 MBGTEB 会回落到「基础 CDN 替换逻辑」。「基础 CDN 替换逻辑」依然会尽可能替换 PCDN/MCDN/HTTP 302 CDN 域名，但是无法实现 负载均衡 或 按类型优选 CDN。